### PR TITLE
Set status codes for custom 404 and "work in progress" views

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -440,9 +440,15 @@ def submit_curated_dataset(request):
 
 def get_error_404_view(request, exception):
     """Return the custom 404 page."""
-    return render(request, 'dashboard/404.html')
+
+    response = render(request, 'dashboard/404.html')
+    response.status_code = 404  # Not Found
+    return response
 
 
 def get_work_in_progress_view(request):
     """Return work-in-progress view."""
-    return render(request, 'dashboard/work-in-progress.html')
+
+    response = render(request, 'dashboard/work-in-progress.html')
+    response.status_code = 501  # Not Implemented
+    return response


### PR DESCRIPTION
These views didn't have an HTTP status code set, so they were using the default (200 OK) which isn't quite appropriate. Setting the appropriate HTTP codes allows features like error logging, as well as providing hints to browsers on how to handle the given page (for instance by not saving 404 pages to history).