### PR TITLE
Fix create_superuser function

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -129,12 +129,12 @@ class UserManager(BaseUserManager):
         user.save()
         return user
 
-    def create_superuser(self, email):
+    def create_superuser(self, email, password):
         """
         Creates and saves a user as superuser
         """
         email = self.normalize_email(email)
-        user = self.create_user(email)
+        user = self.create_user(email, password)
         user.is_staff()
         user.is_superuser = True
         user.save()


### PR DESCRIPTION
The `create_superuser` function is used to create a new superuser in the database; however it wasn't working since it was missing the `password` argument. This commit fixes that problem.

Superuser creation is not something one does often in production; however it is a useful function to have during development when one may be resetting the database often and require access to test the admin interface.