### PR TITLE
Restyle answer questions

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -50,6 +50,46 @@ class QuestionArchive(models.Model):
     created_on = models.DateTimeField(auto_now_add=True)
     updated_on = models.DateTimeField(auto_now=True)
 
+    def accept_question(self, acceptor):
+        """
+        Mark a question as approved, by the given acceptor (user).
+
+        This basically changes a question from unmoderated to moderated
+        by removing the QuestionArchive record and replacing it with
+        a Question one.
+        """
+
+        q = Question()
+        q.school = self.school
+        q.area = self.area
+        q.state = self.state
+        q.student_name = self.student_name
+        q.student_gender = self.student_gender
+        q.student_class = self.student_class
+        q.question_text = self.question_text
+        q.question_text_english = self.question_text_english
+        q.question_format = self.question_format
+        q.question_language = self.question_language
+        q.contributor = self.contributor
+        q.contributor_role = self.contributor_role
+        q.context = self.context
+        q.medium_language = self.medium_language
+        q.curriculum_followed = self.curriculum_followed
+        q.published = self.published
+        q.published_source = self.published_source
+        q.published_date = self.published_date
+        q.question_asked_on = self.question_asked_on
+        q.notes = self.notes
+        q.created_on = self.created_on
+        q.updated_on = self.updated_on
+        q.submitted_by = self.submitted_by
+        q.curated_by = acceptor
+        try:
+            q.save()
+            self.delete()
+        except Exception as e:
+            print('Error accepting question: %s' % e)
+
     def __str__(self):
         return self.question_text
 

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -82,7 +82,7 @@
     </div>
 </div>
 {% endif %}
-<form action="{% url 'dashboard:submit-answer' %}" class="rich-text-form input-area" method="POST">
+<form action="{% url 'dashboard:answer-question' question_id=question.id %}" class="rich-text-form input-area" method="POST">
     {% csrf_token %}
 
     <div id="editor" data-placeholder="Type your answer here..."></div>

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -1,4 +1,4 @@
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% load static %}
 

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -87,7 +87,6 @@
 
     <div id="editor" data-placeholder="Type your answer here..."></div>
 
-    <hr />
     <div id="toolbar" class="row justify-content-end">
         <span class="ql-formats">
             <button class="ql-bold"></button>
@@ -113,7 +112,6 @@
         </span>
     </div>
     {# TODO: Make editor more like Gmail's (as copied in design) #}
-    <hr />
 
     <div class="submit-toolbar row">
 		<div class="col-sm">

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -8,11 +8,10 @@
 
 {% block title %} Answer Question | Sawaliram {% endblock %}
 
-{% block content %}
-
-<h1 class="question-text-heading">{{ question.question_text }}</h1>
-
+{% block extra_header %}
+<hr />
 <div class="answer-question highlighted-meta-area">
+    <h1 class="question-text-heading">{{ question.question_text }}</h1>
     {% if question.student_class %}
         <span class="highlighted-meta">
             <i class="fas fa-user-graduate"></i></i>
@@ -47,11 +46,18 @@
         </span>
     {% endif %}
 </div>
+{% endblock %}
 
-<form action="{% url 'dashboard:submit-answer' %}" class="rich-text-form" method="POST">
+{% block content %}
+<div class="buffer" style="margin-top: 10rem;"></div>
+
+<form action="{% url 'dashboard:submit-answer' %}" class="rich-text-form input-area" method="POST">
     {% csrf_token %}
 
-    <div id="toolbar">
+    <div id="editor" data-placeholder="Type your answer here..."></div>
+
+    <hr />
+    <div id="toolbar" class="row justify-content-end">
         <span class="ql-formats">
             <button class="ql-bold"></button>
             <button class="ql-italic"></button>
@@ -75,19 +81,21 @@
             <button class="ql-formula"></button>
         </span>
     </div>
+    <hr />
 
-    <div id="editor"></div>
-
-    <br>
-    <div class="task-notes">
-        <i class="fas fa-exclamation-circle"></i> Once submitted, your answer will be reviewed by another subject expert, who may approve your answer or suggest changes to it. 
+    <div class="submit-toolbar row">
+		<div class="col-sm">
+		    <input type="hidden" name="question_id" value="{{ question.id }}">
+		    <input type="hidden" name="rich-text-content" value="" />
+		    <button type="submit" class="btn btn-primary">Submit For Review</button>
+		    <button type="submit" class="btn btn-primary btn-primary-hollow" name="mode" value="draft" >Save Draft</button>
+		</div>
+		<div class="col-sm">
+			<a class="btn btn-plain float-right" data-toggle="tooltip" data-placement="left" title="Once submitted, your answer will be reviewed by another subject expert, who may approve your answer or suggest changes to it.">
+			  <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+			</a>
     </div>
-
-    <input type="hidden" name="question_id" value="{{ question.id }}">
-    <input type="hidden" name="rich-text-content" value="" />
-
-    <br>
-    <button type="submit" class="btn btn-block green-button">Submit For Review</button>
+	</div>
 </form>
 
 {% endblock %}

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -8,6 +8,8 @@
 
 {% block title %} Answer Question | Sawaliram {% endblock %}
 
+{# TODO: add breadcrumb, after implemented in base.html #}
+
 {% block extra_header %}
 <hr />
 <div class="answer-question highlighted-meta-area">
@@ -45,6 +47,7 @@
             </span>    
         </span>
     {% endif %}
+    {# TODO: "Previous" and "Next" buttons #}
 </div>
 {% endblock %}
 
@@ -81,6 +84,7 @@
             <button class="ql-formula"></button>
         </span>
     </div>
+    {# TODO: Make editor more like Gmail's (as copied in design) #}
     <hr />
 
     <div class="submit-toolbar row">

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -56,6 +56,14 @@
 	            </span>
 	        </span>
 	    {% endif %}
+	    {% if question.question_asked_on %}
+	        <span class="highlighted-meta">
+	            <i class="fas fa-calendar"></i>
+	            <span class="meta-value">
+	                {{ question.question_asked_on }}
+	            </span>
+	        </span>
+	    {% endif %}
 
 	    {# TODO: "Previous" and "Next" buttons #}
 	</div>

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -120,7 +120,7 @@
 		    <input type="hidden" name="question_id" value="{{ question.id }}">
 		    <input type="hidden" name="rich-text-content" value="" />
 		    <button type="submit" class="btn btn-primary">Submit For Review</button>
-		    <button type="submit" class="btn btn-primary btn-primary-hollow" name="mode" value="draft" >Save Draft</button>
+		    <button type="submit" class="btn btn-primary btn-primary-hollow" name="mode" value="draft" disabled>Save Draft</button>
 		</div>
 	</div>
 </form>

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -67,6 +67,21 @@
 
 	    {# TODO: "Previous" and "Next" buttons #}
 	</div>
+{% if messages %}
+<div class="messages">
+    <div class="alert alert-success alert-dismissible fade show task-success-message" role="alert">
+        {% for message in messages %}
+        <span{% if message.tags %} class="{{ message.tags }}"{% endif %}>
+            <i class="far fa-check-circle"></i>
+            {{ message }}
+        </span>
+        {% endfor %}
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+</div>
+{% endif %}
 <form action="{% url 'dashboard:submit-answer' %}" class="rich-text-form input-area" method="POST">
     {% csrf_token %}
 
@@ -107,11 +122,6 @@
 		    <button type="submit" class="btn btn-primary">Submit For Review</button>
 		    <button type="submit" class="btn btn-primary btn-primary-hollow" name="mode" value="draft" >Save Draft</button>
 		</div>
-		<div class="col-sm">
-			<a class="btn btn-plain float-right" data-toggle="tooltip" data-placement="left" title="Once submitted, your answer will be reviewed by another subject expert, who may approve your answer or suggest changes to it.">
-			  <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
-			</a>
-    </div>
 	</div>
 </form>
 

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -11,49 +11,54 @@
 {# TODO: add breadcrumb, after implemented in base.html #}
 
 {% block extra_header %}
-<hr />
-<div class="answer-question highlighted-meta-area">
-    <h1 class="question-text-heading">{{ question.question_text }}</h1>
-    {% if question.student_class %}
-        <span class="highlighted-meta">
-            <i class="fas fa-user-graduate"></i></i>
-            <span class="meta-value">
-                Grade {{ question.student_class }}
-            </span>
-        </span>
-    {% endif %}
-
-    {% if question.school %}
-        <span class="highlighted-meta">
-            <i class="fas fa-graduation-cap"></i>
-            <span class="meta-value">
-                {{ question.school }}
-                {% if question.curriculum_followed %}
-                    ({{ question.curriculum_followed }})
-                {% endif %}
-            </span>
-        </span>
-    {% endif %}
-
-    {% if question.area or question.state %}
-        <span class="highlighted-meta">
-            <i class="fas fa-map-marker-alt"></i>
-            <span class="meta-value">
-                {% if question.area %}
-                    {{ question.area.rstrip }} {% if question.state %}, {{ question.state }} {% endif %}
-                {% elif question.state %}
-                    {{ question.state }}
-                {% endif %}
-            </span>    
-        </span>
-    {% endif %}
-    {# TODO: "Previous" and "Next" buttons #}
+<div class="navbar-extra row justify-content-end">
+	<div>
+		<button class="btn btn-secondary-hollow">&lt; Prev</button>
+		<button class="btn btn-secondary-hollow">Next &gt;</button>
+	</div>
 </div>
 {% endblock %}
 
 {% block content %}
-<div class="buffer" style="margin-top: 10rem;"></div>
+<div class="buffer" style="margin-top: 1rem;"></div>
+	<div class="answer-question highlighted-meta-area">
+	    <h1 class="question-text-heading">{{ question.question_text }}</h1>
+	    {% if question.student_class %}
+	        <span class="highlighted-meta">
+	            <i class="fas fa-user-graduate"></i></i>
+	            <span class="meta-value">
+	                Grade {{ question.student_class }}
+	            </span>
+	        </span>
+	    {% endif %}
+	
+	    {% if question.school %}
+	        <span class="highlighted-meta">
+	            <i class="fas fa-graduation-cap"></i>
+	            <span class="meta-value">
+	                {{ question.school }}
+	                {% if question.curriculum_followed %}
+	                    ({{ question.curriculum_followed }})
+	                {% endif %}
+	            </span>
+	        </span>
+	    {% endif %}
+	
+	    {% if question.area or question.state %}
+	        <span class="highlighted-meta">
+	            <i class="fas fa-map-marker-alt"></i>
+	            <span class="meta-value">
+	                {% if question.area %}
+	                    {{ question.area.rstrip }} {% if question.state %}, {{ question.state }} {% endif %}
+	                {% elif question.state %}
+	                    {{ question.state }}
+	                {% endif %}
+	            </span>
+	        </span>
+	    {% endif %}
 
+	    {# TODO: "Previous" and "Next" buttons #}
+	</div>
 <form action="{% url 'dashboard:submit-answer' %}" class="rich-text-form input-area" method="POST">
     {% csrf_token %}
 

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -12,16 +12,16 @@ urlpatterns = [
     path('question/validate-curated', views.ValidateCuratedExcelSheet.as_view(), name='validate-curated-excel-sheet'),
     path('question/curate', views.CurateDataset.as_view(), name='curate-dataset'),
     path('manage-content', views.ManageContentView.as_view(), name='manage-content'),
+    path('question/<int:question_id>/answer/new', views.SubmitAnswerView.as_view(), name='answer-question'),
 
     # task pages
     # these URLs point to a task page, like submit-questions
     path('view-questions', views.get_view_questions_view, name='view-questions-view'),
     path('answer-questions-list', views.get_answer_questions_list_view, name='answer-questions-list-view'),
-    path('answer-questions/<int:question_id>/', views.get_answer_question_view, name='answer-question'),
 
     # action URLs
     # these URLs perform an action, like submitting a question
     # they are generally called from a form action
-    path('action/submit-answer', views.submit_answer, name='submit-answer'),
+    # path('action/submit-answer', views.submit_answer, name='submit-answer'),
 
 ]

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -225,6 +225,8 @@ class SubmitAnswerView(View):
 
         question_to_answer = Question.objects.get(pk=question_id)
 
+        # TODO allow saving of drafts
+
         new_answer = Answer()
         new_answer.question_id = question_to_answer
         new_answer.answer_text = request.POST['rich-text-content']

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -3,7 +3,7 @@
 import random
 import os
 
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
@@ -496,7 +496,11 @@ def submit_answer(request):
     new_answer.answered_by = request.user
     new_answer.save()
 
-    return render(request, 'dashboard/excel-submitted-successfully.html')
+    messages.success(request, ('Thank you for submitting your answer! '
+        'Your answer reviewed by another subject expert, who may '
+        'approve your answer or suggest changes to it.'))
+    return redirect('dashboard:answer-question',
+        question_id=new_answer.question_id.id)
 
 
 def get_error_404_view(request, exception):

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -435,7 +435,9 @@ def get_answer_question_view(request, question_id):
     question_to_answer = Question.objects.get(pk=question_id)
 
     context = {
-        'question': question_to_answer
+        'question': question_to_answer,
+        'grey_background': 'True',
+        'page_title': 'Answer Question',
     }
     return render(request, 'dashboard/answer-question.html', context)
 

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -553,6 +553,11 @@ input:focus {
     border-color: #9B63A8;
 }
 
+.navbar-extra {
+    width: 100%;
+    padding: 0.5rem;
+}
+
 /* ======== DASHBOARD_HOME ======== */
 
 h1.dashboard-home-greeting {
@@ -1268,15 +1273,21 @@ button.social-login i {
     font-size: 13px;
 }
 
+.highlighted-meta-area {
+    max-width: 50rem;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 1rem 0;
+}
+
 .highlighted-meta:not(:last-child) {
-    border-right: 1px solid #b7b7b7;
+    border-right: 1px solid #000000;
     margin-right: 10px;
 }
 
 .highlighted-meta i {
     font-size: 13px;
     margin: 0 5px;
-    color: #b7b7b7;
 }
 
 #questionsList .card .card-body .meta-phrase-section {
@@ -1284,7 +1295,7 @@ button.social-login i {
 }
 
 .highlighted-meta .meta-value {
-    color: #777;
+    color: #000;
 }
 
 .empty-result-text {
@@ -1305,6 +1316,8 @@ button.social-login i {
     color: white;
     width: 100%;
     border-top: 1px solid #f2f2f2;
+    margin-left: 0;
+    margin-right: 0;
 }
 
 .navbar .highlighted-meta-area .meta-value,

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -1262,10 +1262,6 @@ button.social-login i {
     font-size: 15px;
 }
 
-.highlighted-meta-area {
-    margin-bottom: 13px;
-}
-
 .highlighted-meta {
     padding: 2px;
     padding-right: 10px;
@@ -1301,6 +1297,19 @@ button.social-login i {
     font-size: 30px;
 }
 
-.answer-question.highlighted-meta-area {
-    margin-bottom: 30px;
+/*-- Highlighted Meta on Menubar --*/
+
+.navbar .highlighted-meta-area {
+    padding: 2rem;
+    background-color: #87b24d;
+    color: white;
+    width: 100%;
+    border-top: 1px solid #f2f2f2;
+}
+
+.navbar .highlighted-meta-area .meta-value,
+.navbar .highlighted-meta-area i
+{
+    color: #ffffff;
+}
 }

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -554,8 +554,10 @@ input:focus {
 }
 
 .navbar-extra {
-    width: 100%;
+    width: calc(100vw + 2rem);
     padding: 0.5rem;
+    padding-right: 2rem;
+    box-shadow: 0 0.7rem 1rem -1rem;
 }
 
 /* ======== DASHBOARD_HOME ======== */

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -105,6 +105,17 @@ input:focus {
     border-color: #759a42;
 }
 
+.btn-primary-hollow {
+    color: #87B24D;
+    background-color: #ffffff;
+    border: 1px solid #87B24D;
+}
+
+.btn-primary-hollow:hover {
+    color: #ffffff;
+    background-color: #87B24D;
+}
+
 .btn-secondary {
     background-color: #9B63A8;
     border-color: #9B63A8;

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -854,6 +854,12 @@ h1.dashboard-home-greeting {
     }
 }
 
+.messages {
+    max-width: 50rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 /* ======== MANAGE CONTENT ======== */
 
 .dataset-list {

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -1312,4 +1312,20 @@ button.social-login i {
 {
     color: #ffffff;
 }
+
+/*----- Answer Questions -----*/
+
+.input-area {
+    max-width: 50rem;
+    margin-left: auto;
+    margin-right: auto;
+    background: white;
+    border-radius: 0.8rem;
+    padding: 1em;
+}
+
+.input-area .ql-container.ql-snow,
+.input-area .ql-toolbar.ql-snow
+{
+	border: none;
 }

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -1348,3 +1348,9 @@ button.social-login i {
 {
 	border: none;
 }
+
+#toolbar {
+    border-top: 1px solid lightgray;
+    border-bottom: 1px solid lightgray;
+    margin-bottom: 0.5rem;
+}

--- a/public_website/static/js/script.js
+++ b/public_website/static/js/script.js
@@ -164,18 +164,23 @@ function processSelectedExcelSheet() {
     });
 }
 
-function setupQuillEditor() {
+function setupQuillEditor({ placeholder = null } = {}) {
 
     var quill = new Quill('#editor', {
         theme: 'snow',
         modules: {
-            toolbar: '#toolbar'
-        }
+            toolbar: '#toolbar',
+        },
+        placeholder: placeholder,
     });
 
     $('.rich-text-form').submit(function(e) {
         $('[name="rich-text-content"]').val(quill.root.innerHTML);
     });
+}
+
+function activateTooltips() {
+  $('[data-toggle="tooltip"]').tooltip()
 }
 
 // ======== CALL GENERAL FUNCTIONS ========
@@ -199,7 +204,8 @@ if (window.location.pathname.includes('/dashboard/question/submit') || window.lo
 }
 
 if (window.location.pathname.includes('/dashboard/answer-questions/')) {
-    setupQuillEditor();
+    setupQuillEditor({ placeholder: 'Type your answer here...' });
+    activateTooltips();
 }
 
 if (window.location.pathname.includes('/user/how-can-i-help')) {

--- a/public_website/static/js/script.js
+++ b/public_website/static/js/script.js
@@ -203,7 +203,8 @@ if (window.location.pathname.includes('/dashboard/question/submit') || window.lo
     processSelectedExcelSheet();
 }
 
-if (window.location.pathname.includes('/dashboard/answer-questions/')) {
+var pattern = new RegExp("^/dashboard/question/\\d+/answer/(new|\\d+)")
+if (pattern.test(window.location.pathname)) {
     setupQuillEditor({ placeholder: 'Type your answer here...' });
     activateTooltips();
 }

--- a/public_website/templates/public_website/base.html
+++ b/public_website/templates/public_website/base.html
@@ -144,6 +144,9 @@
                     </button>
                 {% endif %}
             </div>
+            {% block extra_header %}
+                {# page-specific header/breadcrumbs can go here #}
+            {% endblock %}
         </header>
 
         <div class="container sawaliram-container flex-grow">


### PR DESCRIPTION
Styling has been updated to almost match that proposed by the Design Team (available in Google Docs).

Some things yet to be implemented:

* The breadcrumb/"back to dashboard" button needs to be implemented system-wide in `base.html`
* "Previous"/"Next" buttons, for which the view will have to return the relevant links
* Editor toolbar does not look exactly like the Gmail one (which was copied for the proposed Sawaliram design). The main change required is a drop-down menu to hold extra options
* Info icon has been added providing information about what will happen once the piece was submitted. This could possibly be moved to a "success page" or a pre-submission popup in the future
* "Save Draft" button currently does same action as "Submit" button: view is not yet able to handle drafts.

Additionally, the toolbar takes up too much of the screen space. We need to decide a way to hide/compress this once the user scrolls up (and maybe the design team should decide how this would look).