### PR TITLE
Implement "accept_question" helper method for QuestionArchive

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -50,6 +50,46 @@ class QuestionArchive(models.Model):
     created_on = models.DateTimeField(auto_now_add=True)
     updated_on = models.DateTimeField(auto_now=True)
 
+    def accept_question(self, acceptor):
+        """
+        Mark a question as approved, by the given acceptor (user).
+
+        This basically changes a question from unmoderated to moderated
+        by removing the QuestionArchive record and replacing it with
+        a Question one.
+        """
+
+        q = Question()
+        q.school = self.school
+        q.area = self.area
+        q.state = self.state
+        q.student_name = self.student_name
+        q.student_gender = self.student_gender
+        q.student_class = self.student_class
+        q.question_text = self.question_text
+        q.question_text_english = self.question_text_english
+        q.question_format = self.question_format
+        q.question_language = self.question_language
+        q.contributor = self.contributor
+        q.contributor_role = self.contributor_role
+        q.context = self.context
+        q.medium_language = self.medium_language
+        q.curriculum_followed = self.curriculum_followed
+        q.published = self.published
+        q.published_source = self.published_source
+        q.published_date = self.published_date
+        q.question_asked_on = self.question_asked_on
+        q.notes = self.notes
+        q.created_on = self.created_on
+        q.updated_on = self.updated_on
+        q.submitted_by = self.submitted_by
+        q.curated_by = acceptor
+        try:
+            q.save()
+            self.delete()
+        except Exception as e:
+            print('Error accepting question: %s' % e)
+
     def __str__(self):
         return self.question_text
 


### PR DESCRIPTION
Adding this function because it's useful to quickly set up test data (and will probably be useful for the "Approve Questions" view, whenever that's ready).

The reason it's useful for test-data is, if the questions are imported as an Excel Sheet they get saved under QuestionArchive instead of Question, which means I can't use them to eg. test the "List Questions" or "Answer Question" views.

With this function, I can just use a Python loop like the following

    >>> from sawaliram_auth.models import User
    >>> from dashboard.models import QuestionArchive
    >>> u = User.objects.get(email='admin@sawaliram.com')
    >>> for q in QuestionArchive.objects.all(): q.accept_question(u)
    ...
    >>>

...and have all the Questions available for testing with.

An earlier version of this function was already implemented in #38 but hasn't been merged yet and is also a bit outdated right now.