### PR TITLE
Add default name for create_superuser

### DIFF
--- a/sawaliram_auth/models.py
+++ b/sawaliram_auth/models.py
@@ -29,7 +29,7 @@ class UserManager(BaseUserManager):
         Creates and saves a user as superuser
         """
         email = self.normalize_email(email)
-        user = self.create_user(email, password)
+        user = self.create_user('Super', 'User', email, password)
         user.is_staff()
         user.is_superuser = True
         user.save()


### PR DESCRIPTION
The underlying `create_user` function requires the `first_name` and `last_name` parameters to operate; the current setup was failing since those parameters were not provided.